### PR TITLE
Use type annotation syntax in Animator.init example

### DIFF
--- a/src/Animator.elm
+++ b/src/Animator.elm
@@ -243,14 +243,14 @@ type alias Timeline state =
 
 So, if you previously had a `Bool` in your model:
 
-    { checked = Bool }
+    type alias Model = { checked : Bool }
 
     -- created via
     { checked = False }
 
 You could replace that with an `Animator.Timeline Bool`
 
-    { checked = Animator.Timeline Bool }
+    type alias Model = { checked : Animator.Timeline Bool }
 
     -- created via
     { checked = Aniamtor.init False }


### PR DESCRIPTION
I found the type annotation confusing because it was using `=` instead of `:`.
I noticed `elm-format` automatically fixes this because it thinks it's a record. So I added a sample Model definition that would make this example syntactically correct and I think not confusing.