### PR TITLE
Add elm-review configuration

### DIFF
--- a/review/elm.json
+++ b/review/elm.json
@@ -1,0 +1,39 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.2",
+            "elm/json": "1.1.3",
+            "elm/project-metadata-utils": "1.0.1",
+            "jfmengels/elm-review": "2.0.0",
+            "jfmengels/review-common": "1.0.0",
+            "jfmengels/review-debug": "2.0.1",
+            "jfmengels/review-unused": "2.0.0",
+            "stil4m/elm-syntax": "7.1.1"
+        },
+        "indirect": {
+            "elm/html": "1.0.0",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.2",
+            "elm-community/json-extra": "4.2.0",
+            "elm-community/list-extra": "8.2.3",
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-hex": "1.0.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3",
+            "stil4m/structured-writer": "1.0.2"
+        }
+    },
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "1.2.2"
+        },
+        "indirect": {}
+    }
+}

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -1,0 +1,39 @@
+module ReviewConfig exposing (config)
+
+{-| Do not rename the ReviewConfig module or the config function, because
+`elm-review` will look for these.
+
+To add packages that contain rules, add them to this review project using
+
+    `elm install author/packagename`
+
+when inside the directory containing this file.
+
+-}
+
+import NoDebug.Log
+import NoDebug.TodoOrToString
+import NoExposingEverything
+import NoImportingEverything
+import NoMissingTypeAnnotation
+import NoUnused.CustomTypeConstructors
+import NoUnused.Dependencies
+import NoUnused.Exports
+import NoUnused.Modules
+import NoUnused.Variables
+import Review.Rule exposing (Rule)
+
+
+config : List Rule
+config =
+    [ NoDebug.Log.rule
+    , NoDebug.TodoOrToString.rule
+    , NoExposingEverything.rule
+    , NoImportingEverything.rule []
+    , NoMissingTypeAnnotation.rule
+    , NoUnused.CustomTypeConstructors.rule []
+    , NoUnused.Dependencies.rule
+    , NoUnused.Exports.rule
+    , NoUnused.Modules.rule
+    , NoUnused.Variables.rule
+    ]


### PR DESCRIPTION
This adds an `elm-review` to the project.

Since you don't have a `package.json` in your project, just know you should install it via `npm install elm-review` (globally if that's what you prefer), and then run `npx elm-review` or just `elm-review` depending on your system.

I have not fixed any of the errors, and there are quite a lot of them.
I recommend that you start by commenting every rule and turn them on one by one after you fix all the errors, starting with `NoUnused.Variables` for instance. Also, if you don't agree with the rule or don't the value, just remove it.

Some rules (like this last one) can be autofixed. So I recommend
- running `elm-review --fix`, which will prompt you with every fix
- or running `elm-review --fix-all` which will apply all the changes and you can then accept or refuse. Not recommended because fixes are not always perfect, but it can be useful to see the extent of changes you'll have to go through.