### PR TITLE
Fix docs for `wrap`

### DIFF
--- a/src/Animator.elm
+++ b/src/Animator.elm
@@ -157,9 +157,9 @@ Well, in that case you can use an `Oscillator`.
             Animator.at 0
 
         Loading ->
-            -- animate from 0 to 360 and
-            -- then wrap back around to 0
-            Animator.wrap 0 360
+            -- animate from 0deg to 360deg and
+            -- then wrap back around to 0deg
+            Animator.wrap 0 (2 * pi) -- 2 * pi == 360deg
                 -- loop every 700ms
                 |> Animator.loop (Animator.millis 700)
 


### PR DESCRIPTION
Using `360` instead of `(2 * pi)` will spin the loader 57 times.

You can try it here https://ellie-app.com/93T5cxxRPbfa1

Additionally, I wasn't expecting that the button would spin back in this example because `wrap` should end up at `0` right?
Is this a bug or expected? How would you perform just one full rotation clockwise without spinning back when changing the state back to `False`? (let me know if you want me to open an issue)

Thanks for making this awesome library! ❤️ 