### PR TITLE
Added example showing how multiple separate states from a model can be tracked using one `Animator.animator`

### DIFF
--- a/notes/roadmap.md
+++ b/notes/roadmap.md
@@ -12,6 +12,6 @@ With that in mind, I have a few ideas I'm excited about!
   - Dynamically slow down or speed up a timeline to see exactly what's happening in the animation.
   - Interactive curve editor to craft how a transition should work.
 
-- **Direct Svg support** - You can already animation `Svg` with `Animator` by animating a `Float` value via `Animator.move` and then formatting it into the proper attribute.  However there are a few opportunities for improvement!
+- **Direct Svg support** - You can already animate `Svg` with `Animator` by animating a `Float` value via `Animator.move` and then formatting it into the proper attribute.  However there are a few opportunities for improvement!
   - [**SMIL**](https://developer.mozilla.org/en-US/docs/Web/SVG/SVG_animation_with_SMIL) is an animation framework built into Svg.  It was deprecated by chrome, then they brought it back.  `elm-animator` could generate `SMIL` nodes just ike it generates css `@keyframes`.
     - **?** - is `SMIL` performant?  If so, is there some browser it's not performant on?

--- a/src/Animator.elm
+++ b/src/Animator.elm
@@ -1300,7 +1300,26 @@ Here's an animator from the [Checkbox.elm example](https://github.com/mdgriffith
                     { model | checked = newChecked }
                 )
 
-Notice you could add any number of timelines to this animator.
+Notice you could add any number of timelines to this animator:
+
+    animator : Animator.Animator Model
+    animator =
+        Animator.animator
+            |> Animator.watching
+                -- we tell the animator how
+                -- to get the checked timeline using .checked
+                .checked
+                -- and we tell the animator how
+                -- to update that timeline as well
+                (\newChecked model ->
+                    { model | checked = newChecked }
+                )
+            |> Animator.watching
+                .anotherChecked
+                (\anotherCheckboxState ->
+                    { model | anotherChecked = anotherCheckboxState }
+                )
+
 
 **Note** — You likely only need one animator for a given project.
 


### PR DESCRIPTION
It wasn't clear to me how one would use an animator to track multiple separate timelines in a model. 
After taking @mdgriffith 's advice on the elm slack channel, I considered this change would also help others, so I added his example to the documentation showing how multiple states can be tracked by one animator.